### PR TITLE
Fix problem with Entry time type

### DIFF
--- a/raw_converter.go
+++ b/raw_converter.go
@@ -2,6 +2,7 @@ package promtail
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -35,7 +36,7 @@ func NewRawStreamConv(labels, sep string) StreamConverter {
 
 func (s *rawStreamConv) ConvertEntry(bytes []byte) (Entry, error) {
 	now := time.Now().UnixNano()
-	return Entry{now, string(bytes)}, nil
+	return Entry{strconv.FormatInt(now, 10), string(bytes)}, nil
 }
 
 func (s *rawStreamConv) ExtractLabels(bytes []byte) (LabelSet, error) {


### PR DESCRIPTION
👋 Hello, I'm trying to use your project (great project BTW), but I keep getting the error below:

```
zerolog: could not write event: error: loghttp.PushRequest.Streams: []*loghttp.Stream: unmarshalerDecoder: Value looks like Number/Boolean/None, but can't find its end: ',' or '}' symbol, error found in #10 byte of ...|n\"}\n"]]}]}|..., bigger context ...|\",\"message\":\"stopping the application\"}\n"]]}]}|...
```

After a few hours I discovered that the `Loki` API want's the value as a string, I tested against `Grafana Cloud`.